### PR TITLE
chore: remove ini vscode recommendation

### DIFF
--- a/template/.vscode/extensions.json
+++ b/template/.vscode/extensions.json
@@ -3,7 +3,6 @@
         "adamviola.parquet-explorer",
         "charliermarsh.ruff",
         "davidanson.vscode-markdownlint",
-        "davidwang.ini-for-vscode",
         "github.vscode-github-actions",
         "github.vscode-pull-request-github",
         "gruntfuggly.todo-tree",


### PR DESCRIPTION
## Summary
- drop ini-for-vscode from the recommended extensions list

## Rationale
- extension is no longer desired per issue guidance

## Changes
- remove davidwang.ini-for-vscode from template/.vscode/extensions.json recommendations

Fixes #55

No tests needed for this docs/config tweak.