### PR TITLE
update workflow rules test environment to use editable core package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Human-readable log of changes between versions. Follows the [Common Changelog st
 
 - Removed deprecated `tenacity` dependency
 - Updated development environment setup to use `conda_update_dev_runner` instead of updating all conda environments.
+- Generated project tox `workflow-rules` tests have access to the core package deps for schema validation and extract functions
 
 ### Added
 

--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -87,7 +87,7 @@ commands = {envpython} -m mypy
 
 [testenv:py{311,312}-workflow-rules]
 description = Snakemake rule integration tests. Requires network connection to build snakemake conda environment caches
-package = skip
+package = editable
 extras =
 dependency_groups = workflow,test
 setenv =


### PR DESCRIPTION

## Summary

The tox `workflow-rules` integration tests should have access to the core aspects of the package for schema validation and extract functions.

Linked issues:
<!-- GitHub will auto-link issues if the branch name includes them or "Fixes #..." is used in the description. -->

## Checklist

- [x] `CHANGELOG.md` updated with relevant changes.
- [ ] Relevant README files throughout the codebase are updated.
- [ ] Relevant documentation for the project is updated: `docs/docs/`
- [ ] Relevant documentation in the template is updated: `template/docs/docs/`
- [ ] Tests added or updated as necessary.
- [ ] All tests pass locally.
- [ ] Code adheres to project style, format, and linting rules.
- [ ] Changes are scoped and focused (no mixed concerns).
- [ ] Branch is up to date with `main` and any conflicts are resolved.
- [ ] Appropriate labels applied to the PR (e.g., bug, enhancement, documentation).

## Notes for Reviewers

<!-- Add any relevant implementation details, design choices, or areas that need special attention. -->
